### PR TITLE
Add built-in month strings definitions

### DIFF
--- a/example/var_not_found.bib
+++ b/example/var_not_found.bib
@@ -1,0 +1,5 @@
+@string{x={blah}}
+@article{v,
+    title = mar,
+    x = "X",
+}


### PR DESCRIPTION
Addresses standard month abbreviations not being printed
when they have not been defined raised by #9.