### PR TITLE
Return scan error as error not log.Fatal

### DIFF
--- a/bibtex.y
+++ b/bibtex.y
@@ -80,7 +80,9 @@ func Parse(r io.Reader) (*BibTex, error) {
 	l := newLexer(r)
 	bibtexParse(l)
 	select {
-	case err := <-l.Errors:
+	case err := <-l.Errors: // Non-yacc errors
+		return nil, err
+	case err := <-l.ParseErrors:
 		return nil, err
 	default:
 		return bib, nil

--- a/bibtex_test.go
+++ b/bibtex_test.go
@@ -2,6 +2,7 @@ package bibtex
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -142,6 +143,21 @@ func TestPrettyStringRoundTrip(t *testing.T) {
 
 		// Check equality.
 		AssertEntryListsEqual(t, bib.Entries, bib2.Entries)
+	}
+}
+
+func TestUnexpectedAtSign(t *testing.T) {
+	// Tests correct syntax but scanning error
+	b, err := ioutil.ReadFile("example/unexpected-at-sign.badbib")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Parse(bytes.NewReader(b))
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !errors.Is(err, ErrUnexpectedAtsign) {
+		t.Fatalf("expected error %+v but got %+v", ErrUnexpectedAtsign, err)
 	}
 }
 

--- a/error.go
+++ b/error.go
@@ -7,9 +7,9 @@ import (
 
 var (
 	// ErrUnexpectedAtsign is an error for unexpected @ in {}.
-	ErrUnexpectedAtsign = errors.New("Unexpected @ sign")
+	ErrUnexpectedAtsign = errors.New("unexpected @ sign")
 	// ErrUnknownStringVar is an error for looking up undefined string var.
-	ErrUnknownStringVar = errors.New("Unknown string variable")
+	ErrUnknownStringVar = errors.New("unknown string variable")
 )
 
 // ErrParse is a parse error.
@@ -19,5 +19,5 @@ type ErrParse struct {
 }
 
 func (e *ErrParse) Error() string {
-	return fmt.Sprintf("Parse failed at %s: %s", e.Pos, e.Err)
+	return fmt.Sprintf("parse failed at %s: %s", e.Pos, e.Err)
 }

--- a/example/unexpected-at-sign.badbib
+++ b/example/unexpected-at-sign.badbib
@@ -1,0 +1,3 @@
+@misc{web,
+    y = {ab@cd},
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/nickng/bibtex
 
-go 1.13
+go 1.18
 
 require github.com/BurntSushi/toml v0.3.1

--- a/lexer.go
+++ b/lexer.go
@@ -2,27 +2,39 @@
 
 package bibtex
 
-import "io"
+import (
+	"fmt"
+	"io"
+)
 
 // lexer for bibtex.
 type lexer struct {
-	scanner *scanner
-	Errors  chan error
+	scanner     *scanner
+	ParseErrors chan error // Parse errors from yacc
+	Errors      chan error // Other errors
 }
 
 // newLexer returns a new yacc-compatible lexer.
 func newLexer(r io.Reader) *lexer {
-	return &lexer{scanner: newScanner(r), Errors: make(chan error, 1)}
+	return &lexer{
+		scanner:     newScanner(r),
+		ParseErrors: make(chan error, 1),
+		Errors:      make(chan error, 1),
+	}
 }
 
 // Lex is provided for yacc-compatible parser.
 func (l *lexer) Lex(yylval *bibtexSymType) int {
-	token, strval := l.scanner.Scan()
+	token, strval, err := l.scanner.Scan()
+	if err != nil {
+		l.Errors <- fmt.Errorf("%w at %s", err, l.scanner.pos)
+		return int(0)
+	}
 	yylval.strval = strval
 	return int(token)
 }
 
 // Error handles error.
 func (l *lexer) Error(err string) {
-	l.Errors <- &ErrParse{Err: err, Pos: l.scanner.pos}
+	l.ParseErrors <- &ErrParse{Err: err, Pos: l.scanner.pos}
 }


### PR DESCRIPTION
This change changes the behaviour of error when there's an unexpected error inside fields like:

```
@misc{example,
  f = {ab@cd}
}
```
Where previously the scanner calls `log.Fatal` when encountering an unexpected `@` - because parsing cannot proceed.
Here we change it so that this returns an error to the `Parse()` call so that caller can decide what to do with the error (just like a syntax error).

Closes #15