### PR TITLE
Pretty print individual BibEntry and allow custom key order

### DIFF
--- a/bibtex_test.go
+++ b/bibtex_test.go
@@ -205,3 +205,27 @@ func BenchmarkStringPerformance(b *testing.B) {
 		_ = bib.String()
 	}
 }
+
+func TestBibEntry_PrettyStringCustomOrder(t *testing.T) {
+	wantPrettyString := `@inproceedings{bibtexKey,
+    author    = "A a and B b and C c",
+    editor    = "D d and E e",
+    title     = "Some title",
+    booktitle = "Some booktitle",
+}
+`
+
+	entry := NewBibEntry("inproceedings", "bibtexKey")
+	entry.AddField("author", NewBibConst("A a and B b and C c"))
+	entry.AddField("editor", NewBibConst("D d and E e"))
+	entry.AddField("title", NewBibConst("Some title"))
+	entry.AddField("booktitle", NewBibConst("Some booktitle"))
+
+	keyOrder := []string{"author", "editor", "title", "booktitle"}
+	gotPrettyString := entry.PrettyStringCustomOrder(keyOrder)
+
+	if wantPrettyString != gotPrettyString {
+		t.Errorf("Format error\nWant: %s\nGot:%s\n", wantPrettyString, gotPrettyString)
+	}
+
+}

--- a/bibtex_test.go
+++ b/bibtex_test.go
@@ -222,10 +222,19 @@ func TestBibEntry_PrettyStringCustomOrder(t *testing.T) {
 	entry.AddField("booktitle", NewBibConst("Some booktitle"))
 
 	keyOrder := []string{"author", "editor", "title", "booktitle"}
-	gotPrettyString := entry.PrettyStringCustomOrder(keyOrder)
+	gotPrettyString := entry.PrettyString(WithKeyOrder(keyOrder))
 
 	if wantPrettyString != gotPrettyString {
 		t.Errorf("Format error\nWant: %s\nGot:%s\n", wantPrettyString, gotPrettyString)
+	}
+
+	// pretty print same entry with different order and check that result no longer matchnes
+	// wantPrettyString
+	errorKeyOrder := []string{"editor", "author", "title", "booktitle"}
+	gotPrettyString = entry.PrettyString(WithKeyOrder(errorKeyOrder))
+
+	if wantPrettyString == gotPrettyString {
+		t.Errorf("Format error. Expected missmatch but got match")
 	}
 
 }


### PR DESCRIPTION
Hi,
awesome library. I was missing these features when using it an thought I create a pull request.
Changes:
1) Allow to pretty print individual `BibEntry` structs
2) Allow a custom order for pretty printing for both `BibEntry` and `BibTex` structs