### PR TITLE
Use a slice to accumulate errors

### DIFF
--- a/bibtex.y
+++ b/bibtex.y
@@ -79,11 +79,11 @@ tags : tag            { if $1 != nil { $$ = []*bibTag{$1}; } }
 func Parse(r io.Reader) (*BibTex, error) {
 	l := newLexer(r)
 	bibtexParse(l)
-	select {
-	case err := <-l.Errors: // Non-yacc errors
-		return nil, err
-	case err := <-l.ParseErrors:
-		return nil, err
+	switch {
+	case len(l.Errors) > 0: // Non-yacc errors
+		return nil, l.Errors[0]
+	case len(l.ParseErrors) > 0:
+		return nil, l.ParseErrors[0]
 	default:
 		return bib, nil
 	}

--- a/bibtex.y.go
+++ b/bibtex.y.go
@@ -77,11 +77,11 @@ const bibtexInitialStackSize = 16
 func Parse(r io.Reader) (*BibTex, error) {
 	l := newLexer(r)
 	bibtexParse(l)
-	select {
-	case err := <-l.Errors: // Non-yacc errors
-		return nil, err
-	//case err := <-l.ParseErrors:
-	//	return nil, err
+	switch {
+	case len(l.Errors) > 0: // Non-yacc errors
+		return nil, l.Errors[0]
+	case len(l.ParseErrors) > 0:
+		return nil, l.ParseErrors[0]
 	default:
 		return bib, nil
 	}

--- a/lexer.go
+++ b/lexer.go
@@ -10,16 +10,14 @@ import (
 // lexer for bibtex.
 type lexer struct {
 	scanner     *scanner
-	ParseErrors chan error // Parse errors from yacc
-	Errors      chan error // Other errors
+	ParseErrors []error // Parse errors from yacc
+	Errors      []error // Other errors
 }
 
 // newLexer returns a new yacc-compatible lexer.
 func newLexer(r io.Reader) *lexer {
 	return &lexer{
-		scanner:     newScanner(r),
-		ParseErrors: make(chan error, 1),
-		Errors:      make(chan error, 1),
+		scanner: newScanner(r),
 	}
 }
 
@@ -27,7 +25,7 @@ func newLexer(r io.Reader) *lexer {
 func (l *lexer) Lex(yylval *bibtexSymType) int {
 	token, strval, err := l.scanner.Scan()
 	if err != nil {
-		l.Errors <- fmt.Errorf("%w at %s", err, l.scanner.pos)
+		l.Errors = append(l.Errors, fmt.Errorf("%w at %s", err, l.scanner.pos))
 		return int(0)
 	}
 	yylval.strval = strval
@@ -36,5 +34,5 @@ func (l *lexer) Lex(yylval *bibtexSymType) int {
 
 // Error handles error.
 func (l *lexer) Error(err string) {
-	l.ParseErrors <- &ErrParse{Err: err, Pos: l.scanner.pos}
+	l.ParseErrors = append(l.ParseErrors, &ErrParse{Err: err, Pos: l.scanner.pos})
 }


### PR DESCRIPTION
Instead of using a buffered channel to return errors, use two slices
to accumulate all errors, and return other errors before yacc-errors.

Thanks @its-luca for point this out: https://github.com/nickng/bibtex/pull/19#issuecomment-1217788238