### PR TITLE
Support accent characters in the bib key.

### DIFF
--- a/example/biblatex-examples.bib
+++ b/example/biblatex-examples.bib
@@ -1672,3 +1672,12 @@
                   the \texttt{type} field in the database file which uses a
                   localization key},
 }
+
+@inproceedings{Müller2024a,
+	author = {Philipp Müller and Niklas Niere and Felix Lange and Juraj Somorovsky},
+	title = {Turning Attacks into Advantages: Evading {HTTP} Censorship with {HTTP} Request Smuggling},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {},
+	year = {2024},
+	url = {https://www.petsymposium.org/foci/2024/foci-2024-0012.pdf},
+}

--- a/token.go
+++ b/token.go
@@ -29,8 +29,18 @@ func isWhitespace(ch rune) bool {
 	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
 }
 
+func isAccent(ch rune) bool {
+	accents := "äöüßéêçñÁÉÍÓÚáéíóúàèìòùâêîôûãõñÄÖÜ"
+	for _, accent := range accents {
+		if ch == accent {
+			return true
+		}
+	}
+	return false
+}
+
 func isAlpha(ch rune) bool {
-	return ('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z')
+	return ('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z') || isAccent(ch)
 }
 
 func isDigit(ch rune) bool {


### PR DESCRIPTION
Hi @nickng , first of all, thank you so much for creating and maintaining this tool. In my field (anti-censorship), there is a go-to place for people to track the latest and historical related publications, called [censorbib](https://censorbib.nymity.ch/) ([Github repo](https://github.com/NullHypothesis/censorbib)). And it relies on your bibtex parser.

---

This pull request enables the support of accent characters in the bib key:

> @inproceedings{Müller2024a,

Without this commit, the accent characters will cause the parse error, e.g.:

> Cannot parse valid bibtex file example/biblatex-examples.bib: parse failed at 1676:17: syntax error

One real-world use case is available at: https://github.com/NullHypothesis/censorbib/pull/51.